### PR TITLE
fix SyntaxWarning: "is" with 'str' literal. Did you mean "=="?

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,14 @@ Badge
 You can show that your README is tested with this badge: [![Examples tested with pytest-readme](http://img.shields.io/badge/readme-tested-brightgreen.svg)](https://github.com/boxed/pytest-readme) Copy paste the markdown syntax below:
 
     [![Examples tested with pytest-readme](http://img.shields.io/badge/readme-tested-brightgreen.svg)](https://github.com/boxed/pytest-readme)
+
+
+Development
+===========
+To quickly get started, run the following commands:
+
+```sh
+uv venv
+uv pip install -e .
+.venv/bin/python -m pytest
+```

--- a/pytest_readme/__init__.py
+++ b/pytest_readme/__init__.py
@@ -13,7 +13,7 @@ def setup():
                     output[i] = '    """\n'
                 mode = None
                 continue
-            elif mode is 'first_line':
+            elif mode == 'first_line':
                 if line.strip() == '':
                     mode = None
                     output[i - 1] = '\n'


### PR DESCRIPTION
First, follow "Development" in README.

Then run the following:

    # Clear caches, because the warning is only shown when Python
    # compiles.
    find . -type d -name __pycache__ -exec rm -r {} +
    .venv/bin/python -m pytest

Expected: Tests are green.

Actual:

    pytest_readme/__init__.py:16
      /home/felix/github/pytest-readme/pytest_readme/__init__.py:16: SyntaxWarning: "is" with 'str' literal. Did you mean "=="?
        elif mode is 'first_line':

    -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html